### PR TITLE
Changing Updates

### DIFF
--- a/API.paw
+++ b/API.paw
@@ -5,7 +5,7 @@
     <databaseInfo>
         <version>134481920</version>
         <UUID>6EA1A6BB-BF2A-4FBF-8AD5-2C0504CFBBE6</UUID>
-        <nextObjectID>125</nextObjectID>
+        <nextObjectID>127</nextObjectID>
         <metadata>
             <plist version="1.0">
                 <dict>
@@ -114,7 +114,7 @@
         <attribute name="redirectauthorization" type="bool">0</attribute>
         <attribute name="method" type="string">GET</attribute>
         <attribute name="followredirects" type="bool">0</attribute>
-        <attribute name="order" type="int64">2</attribute>
+        <attribute name="order" type="int64">3</attribute>
         <attribute name="name" type="string">Get Existing Manifest</attribute>
         <relationship name="parent" type="0/1" destination="LMREQUESTTREEITEM" idrefs="z120"></relationship>
         <relationship name="children" type="0/0" destination="LMREQUESTTREEITEM"></relationship>
@@ -129,7 +129,7 @@
         <attribute name="redirectauthorization" type="bool">0</attribute>
         <attribute name="method" type="string">PUT</attribute>
         <attribute name="followredirects" type="bool">0</attribute>
-        <attribute name="body" type="string">[{"data":{"json":"{\\"name\\":\\"This Here Web\\",\\"short_name\\":\\"THW\\"}"},"identifier":"com.luckymarmot.JSONDynamicValue"}]</attribute>
+        <attribute name="body" type="string">["{\\n  \\"name\\": \\"This Here Web\\",\\n  \\"short_name\\": \\"THW\\",\\n  \\"start_url\\": \\"http:\\/\\/www.foo.com\\"\\n}"]</attribute>
         <attribute name="order" type="int64">1</attribute>
         <attribute name="name" type="string">Update Manifest</attribute>
         <relationship name="parent" type="0/1" destination="LMREQUESTTREEITEM" idrefs="z120"></relationship>
@@ -175,7 +175,7 @@
         <attribute name="redirectauthorization" type="bool">0</attribute>
         <attribute name="method" type="string">POST</attribute>
         <attribute name="followredirects" type="bool">0</attribute>
-        <attribute name="order" type="int64">4</attribute>
+        <attribute name="order" type="int64">5</attribute>
         <attribute name="name" type="string">Build project</attribute>
         <relationship name="parent" type="0/1" destination="LMREQUESTTREEITEM" idrefs="z120"></relationship>
         <relationship name="children" type="0/0" destination="LMREQUESTTREEITEM"></relationship>
@@ -227,7 +227,7 @@
         <attribute name="order" type="int64">0</attribute>
         <attribute name="name" type="string">manifests</attribute>
         <relationship name="parent" type="0/1" destination="LMREQUESTTREEITEM"></relationship>
-        <relationship name="children" type="0/0" destination="LMREQUESTTREEITEM" idrefs="z107 z108 z112 z102 z124"></relationship>
+        <relationship name="children" type="0/0" destination="LMREQUESTTREEITEM" idrefs="z126 z112 z108 z107 z102 z124"></relationship>
         <relationship name="bodyparameters" type="0/0" destination="LMKEYVALUE"></relationship>
         <relationship name="headers" type="0/0" destination="LMKEYVALUE"></relationship>
         <relationship name="urlparameters" type="0/0" destination="LMKEYVALUE"></relationship>
@@ -277,7 +277,7 @@
         <attribute name="redirectauthorization" type="bool">0</attribute>
         <attribute name="method" type="string">GET</attribute>
         <attribute name="followredirects" type="bool">0</attribute>
-        <attribute name="order" type="int64">3</attribute>
+        <attribute name="order" type="int64">4</attribute>
         <attribute name="name" type="string">Get Existing Manifest Duplicate</attribute>
         <relationship name="parent" type="0/1" destination="LMREQUESTTREEITEM" idrefs="z120"></relationship>
         <relationship name="children" type="0/0" destination="LMREQUESTTREEITEM"></relationship>
@@ -292,5 +292,31 @@
         <relationship name="groupforheaders" type="0/1" destination="LMREQUESTGROUP"></relationship>
         <relationship name="groupforurlparameters" type="0/1" destination="LMREQUESTGROUP"></relationship>
         <relationship name="request" type="0/1" destination="LMREQUEST" idrefs="z124"></relationship>
+    </object>
+    <object type="LMREQUEST" id="z126">
+        <attribute name="uuid" type="string">7861B1DB-6FDA-4102-A583-741D4608FFAA</attribute>
+        <attribute name="url" type="string">["http:\\/\\/",{"data":{"environmentVariable":"86D75205-6B00-4E18-8580-CB1094D18F62"},"identifier":"com.luckymarmot.EnvironmentVariableDynamicValue"},":",{"data":{"environmentVariable":"BA35653F-EDE5-4DE4-A95E-5CFBB6D6A388"},"identifier":"com.luckymarmot.EnvironmentVariableDynamicValue"},"\\/manifests\\/",{"data":{"request":"EE904A70-DD63-4168-944E-CA3664838FF1","keyPath":"id","format":1},"identifier":"com.luckymarmot.ResponseBodyPathDynamicValue"}]</attribute>
+        <attribute name="storecookies" type="bool">1</attribute>
+        <attribute name="sendcookies" type="bool">1</attribute>
+        <attribute name="redirectmethod" type="bool">0</attribute>
+        <attribute name="redirectauthorization" type="bool">0</attribute>
+        <attribute name="method" type="string">PUT</attribute>
+        <attribute name="followredirects" type="bool">0</attribute>
+        <attribute name="body" type="string">[{"data":{"json":"{\\"name\\":\\"This Here Web\\",\\"start_url\\":\\"http:\\\\\\/\\\\\\/www.foo.com\\"}"},"identifier":"com.luckymarmot.JSONDynamicValue"}]</attribute>
+        <attribute name="order" type="int64">2</attribute>
+        <attribute name="name" type="string">Remove Field</attribute>
+        <relationship name="parent" type="0/1" destination="LMREQUESTTREEITEM" idrefs="z120"></relationship>
+        <relationship name="children" type="0/0" destination="LMREQUESTTREEITEM"></relationship>
+        <relationship name="headers" type="0/0" destination="LMKEYVALUE" idrefs="z127"></relationship>
+    </object>
+    <object type="LMKEYVALUE" id="z127">
+        <attribute name="value" type="string"></attribute>
+        <attribute name="order" type="int64">0</attribute>
+        <attribute name="name" type="string"></attribute>
+        <attribute name="enabled" type="bool">1</attribute>
+        <relationship name="groupforbodyparameters" type="0/1" destination="LMREQUESTGROUP"></relationship>
+        <relationship name="groupforheaders" type="0/1" destination="LMREQUESTGROUP"></relationship>
+        <relationship name="groupforurlparameters" type="0/1" destination="LMREQUESTGROUP"></relationship>
+        <relationship name="request" type="0/1" destination="LMREQUEST" idrefs="z126"></relationship>
     </object>
 </database>

--- a/src/services/manifold.js
+++ b/src/services/manifold.js
@@ -50,7 +50,7 @@ Manifold.prototype.updateManifest = function(manifestId,updates,client) {
             if(!reply) return reject(new Error('Manifest not found'));
 
             var manifest = JSON.parse(reply);
-            manifest.content = _.assign(manifest.content,updates);
+            manifest.content = updates;
 
             self.lib.manifestTools.validateManifest(manifest, platforms, function(err,results){
                 if(err){ return reject(err); }

--- a/test/accpetance/manifests.js
+++ b/test/accpetance/manifests.js
@@ -142,6 +142,17 @@ describe('manifests',function(){
                     .end(done);
             });
 
+            it('should remove any fields that no longer exist',function(done){
+                var name = 'Bar Interwebs Associates, Inc.';
+
+                req.put('/manifests/'+manifestId)
+                    .send({name: name, start_url: 'www.fwellc.com'})
+                    .expect(function(res){
+                        expect(res.body.content.short_name).to.equal(undefined);
+                    })
+                    .end(done);
+            });
+
             it('should save the manifest to redis',function(done){
                 sinon.spy(client,'set');
 


### PR DESCRIPTION
Previously updates were using `_.assign()` to change the manifest, but this wouldn't allow fields to be removed.  Now the API expects the payload to contain the entire object instead of just updates.  This addresses #12.
