### PR TITLE
Error Handling

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -33,7 +33,7 @@
         "inject",
         "spyOn"
     ],
-    "indent": 4, // Specify indentation spacing
+    "indent": 2, // Specify indentation spacing
     "devel": true, // Allow development statements e.g. `console.log();`.
     "noempty": true // Prohibit use of empty blocks.
 }

--- a/src/controllers/manifests.js
+++ b/src/controllers/manifests.js
@@ -1,85 +1,87 @@
 'use strict';
 
-var path      = require('path'),
-    outputDir = path.join(__dirname, '../../tmp'),
-    config    = require(path.join(__dirname,'../config')),
-    platforms = config.platforms;
+var path    = require('path'),
+  outputDir = path.join(__dirname, '../../tmp'),
+  config    = require(path.join(__dirname,'../config')),
+  platforms = config.platforms;
 
 exports.create = function(client, storage, manifold){
-    return {
-        show: function(req,res,next){
-            client.get(req.params.id,function(err,reply){
-                if(err) return next(err);
-                if(!reply) return res.status(404).send('NOT FOUND');
+  return {
+    show: function(req,res,next){
+      client.get(req.params.id,function(err,reply){
+        if(err) return next(err);
+        if(!reply) return res.status(404).send('NOT FOUND');
 
-                var manifest = JSON.parse(reply);
-                res.json(manifest);
-            });
-        },
-        create: function(req,res,next){
-            if(req.body.siteUrl){
-                manifold.createManifestFromUrl(req.body.siteUrl,client)
-                    .then(function(manifest){
-                        res.json(manifest);
-                    })
-                    .fail(function(err){
-                        if(err.message === 'Failed to retrieve manifest from site.'){
-                            return res.status(422).json({error: 'Failed to retrieve manifest from site.'});
-                        }else{
-                            return next(err);
-                        }
+        var manifest = JSON.parse(reply);
+        res.json(manifest);
+      });
+    },
+    create: function(req,res,next){
+      if(req.body.siteUrl){
+        manifold.createManifestFromUrl(req.body.siteUrl,client)
+        .then(function(manifest){
+          res.json(manifest);
+        })
+        .fail(function(err){
+          if(err.message === 'Failed to retrieve manifest from site.'){
+            return res.status(422).json({error: 'Failed to retrieve manifest from site.'});
+          }else{
+            return next(err);
+          }
 
-                    });
-            }else if(req.files.file){
-                var file = req.files.file;
-                manifold.createManifestFromFile(file,client)
-                    .then(function(manifest){
-                        res.json(manifest);
-                    })
-                    .fail(function(err){
-                        return next(err);
-                    });
-            }else{
-                next(new Error('No url or manifest provided'));
-            }
-        },
-        update: function(req,res,next){
-            manifold.updateManifest(req.params.id,req.body,client)
-                .then(function(manifest){
-                    res.json(manifest);
-                })
-                .fail(function(err){
-                    if(err.message === 'Manifest not found'){
-                        return res.status(404).json({error: err});
-                    }
-
-                    next(err);
-                });
-        },
-        build: function(req,res,next){
-            client.get(req.params.id,function(err,reply){
-                if(err) return next(err);
-                if(!reply) return res.status(404).send('NOT FOUND');
-
-                var manifest = JSON.parse(reply),
-                    output = path.join(outputDir,manifest.id);
-
-                manifold.normalize(manifest)
-                    .then(function(normManifest){
-                        manifest = normManifest;
-                        return manifold.createProject(manifest,output,platforms,false);
-                    })
-                    .then(function(){ return storage.setPermissions(output); })
-                    .then(function(){ return storage.createZip(output,manifest); })
-                    .then(function(){ return storage.createContainer(manifest); })
-                    .then(function(){ return storage.uploadZip(manifest,output); })
-                    .then(function(){ return storage.removeDir(output); })
-                    .then(function(){ return storage.getUrlForZip(manifest); })
-                    .then(function(url){ res.json({archive: url}); })
-                    .fail(function(error){
-                        return next(error);
-                    });
-            });
+        });
+      }else if(req.files.file){
+        var file = req.files.file;
+        manifold.createManifestFromFile(file,client)
+        .then(function(manifest){
+          res.json(manifest);
+        })
+        .fail(function(err){
+          return next(err);
+        });
+      }else{
+        next(new Error('No url or manifest provided'));
+      }
+    },
+    update: function(req,res,next){
+      manifold.updateManifest(req.params.id,req.body,client)
+      .then(function(manifest){
+        res.json(manifest);
+      })
+      .fail(function(err){
+        if(err.message === 'Manifest not found'){
+          return res.status(404).json({error: err});
         }
-    };
+
+        next(err);
+      });
+    },
+    build: function(req,res){
+      client.get(req.params.id,function(err,reply){
+        if(err){
+          return res.status(500).send('There was a problem loading the project, please try building it again.');
+        }
+        if(!reply) return res.status(404).send('NOT FOUND');
+
+        var manifest = JSON.parse(reply),
+          output = path.join(outputDir,manifest.id);
+
+        manifold.normalize(manifest)
+          .then(function(normManifest){
+            manifest = normManifest;
+            return manifold.createProject(manifest,output,platforms,false);
+          })
+          .then(function(){ return storage.setPermissions(output); })
+          .then(function(){ return storage.createZip(output,manifest); })
+          .then(function(){ return storage.createContainer(manifest); })
+          .then(function(){ return storage.uploadZip(manifest,output); })
+          .then(function(){ return storage.removeDir(output); })
+          .then(function(){ return storage.getUrlForZip(manifest); })
+          .then(function(url){ res.json({archive: url}); })
+          .fail(function(error){
+            return res.status(500).send(error.message);
+          });
+      });
+    }
+  };
 };

--- a/src/services/manifold.js
+++ b/src/services/manifold.js
@@ -1,213 +1,217 @@
 'use strict';
 
 var uuid = require('node-uuid'),
-    Q = require('q'),
-    _ = require('lodash'),
-    path = require('path'),
-    config = require(path.join(__dirname,'../config')),
-    platforms = config.platforms;
+  Q = require('q'),
+  _ = require('lodash'),
+  path = require('path'),
+  config = require(path.join(__dirname,'../config')),
+  platforms = config.platforms;
 
 function Manifold(manifoldLib){
-    this.lib = manifoldLib;
+  this.lib = manifoldLib;
 }
 
 Manifold.prototype.createManifestFromUrl = function(url,client){
-    var self = this;
+  var self = this;
 
-    if(url.indexOf('http') === -1){
-        url = 'http://'+url;
-    }
+  if(url.indexOf('http') === -1){
+    url = 'http://'+url;
+  }
 
-    return Q.Promise(function(resolve,reject){
-        self.lib.manifestTools.getManifestFromSite(url, function(err, manifestInfo) {
-            if (err) {
-                if(err.message !== 'Failed to retrieve manifest from site.'){
-                    return reject(err);
-                }else{
-                    manifestInfo = {
-                        content: {
-                        },
-                        format: 'w3c'
-                    };
-                }
-            }
+  return Q.Promise(function(resolve,reject){
+    self.lib.manifestTools.getManifestFromSite(url, function(err, manifestInfo) {
+      if (err) {
+        if(err.message !== 'Failed to retrieve manifest from site.'){
+          return reject(err);
+        }else{
+          manifestInfo = {
+            content: {
+            },
+            format: 'w3c'
+          };
+        }
+      }
 
-            var manifest = _.assign(manifestInfo,{ id: uuid.v4().slice(0,8) });
+      var manifest = _.assign(manifestInfo,{ id: uuid.v4().slice(0,8) });
 
-            self.validateManifest(manifest)
-                .then(function(manifest){
-                    client.set(manifest.id,JSON.stringify(manifest));
-                    return resolve(manifest);
-                })
-                .fail(reject);
-        });
+      self.validateManifest(manifest)
+      .then(function(manifest){
+        client.set(manifest.id,JSON.stringify(manifest));
+        return resolve(manifest);
+      })
+      .fail(reject);
     });
+  });
 };
 
 Manifold.prototype.createManifestFromFile = function(file,client){
-    var self = this;
+  var self = this;
 
-    return Q.Promise(function(resolve,reject){
-        self.lib.manifestTools.getManifestFromFile(file.path, function (err, manifestInfo) {
-            if (err) { return reject(err); }
+  return Q.Promise(function(resolve,reject){
+    self.lib.manifestTools.getManifestFromFile(file.path, function (err, manifestInfo) {
+      if (err) { return reject(err); }
 
-            var manifest = _.assign(manifestInfo,{ id: uuid.v4().slice(0,8) });
-            self.validateManifest(manifest)
-                .then(function(manifest){
-                    client.set(manifest.id,JSON.stringify(manifest));
-                    return resolve(manifest);
-                })
-                .fail(reject);
-        });
+      var manifest = _.assign(manifestInfo,{ id: uuid.v4().slice(0,8) });
+      self.validateManifest(manifest)
+      .then(function(manifest){
+        client.set(manifest.id,JSON.stringify(manifest));
+        return resolve(manifest);
+      })
+      .fail(reject);
     });
+  });
 };
 
 Manifold.prototype.validateManifest = function(manifest){
-    var self = this;
+  var self = this;
 
-    return Q.Promise(function(resolve,reject){
-        self.lib.manifestTools.validateManifest(manifest, platforms, function(err,results){
-            if(err){ return reject(err); }
+  return Q.Promise(function(resolve,reject){
+    self.lib.manifestTools.validateManifest(manifest, platforms, function(err,results){
+      if(err){ return reject(err); }
 
-            var errors = _.filter(results,{level: 'error'}),
-            suggestions = _.filter(results,{level: 'suggestion'}),
-            warnings = _.filter(results,{level: 'warning'});
+      var errors = _.filter(results,{level: 'error'}),
+        suggestions = _.filter(results,{level: 'suggestion'}),
+        warnings = _.filter(results,{level: 'warning'});
 
-            self.assignValidationErrors(errors,manifest);
-            self.assignSuggestions(suggestions,manifest);
-            self.assignWarnings(warnings,manifest);
+      self.assignValidationErrors(errors,manifest);
+      self.assignSuggestions(suggestions,manifest);
+      self.assignWarnings(warnings,manifest);
 
-            return resolve(manifest);
-        });
+      return resolve(manifest);
     });
+  });
 };
 
 Manifold.prototype.updateManifest = function(manifestId,updates,client) {
-    var self = this;
+  var self = this;
 
-    return Q.Promise(function(resolve,reject){
-        client.get(manifestId,function(err,reply){
-            if(err) return reject(err);
-            if(!reply) return reject(new Error('Manifest not found'));
+  return Q.Promise(function(resolve,reject){
+    client.get(manifestId,function(err,reply){
+      if(err) return reject(err);
+      if(!reply) return reject(new Error('Manifest not found'));
 
-            var manifest = JSON.parse(reply);
-            manifest.content = updates;
+      var manifest = JSON.parse(reply);
+      manifest.content = updates;
 
-            return self.validateManifest(manifest)
-                .then(function(manifest){
-                    client.set(manifest.id,JSON.stringify(manifest));
+      return self.validateManifest(manifest)
+      .then(function(manifest){
+        client.set(manifest.id,JSON.stringify(manifest));
 
-                    resolve(manifest);
-                });
-        });
+        resolve(manifest);
+      });
     });
+  });
 };
 
 Manifold.prototype.normalize = function(manifest){
-    var self = this;
+  var self = this;
 
-    return Q.Promise(function(resolve,reject){
-        console.log('Validating start url...');
-        self.lib.manifestTools.validateAndNormalizeStartUrl(manifest.content.start_url,manifest,function(err,normManifest){
-            if(err){
-                console.log('Normalizing Error',err);
-                return reject(err);
-            }
+  return Q.Promise(function(resolve,reject){
+    console.log('Validating start url...');
+    self.lib.manifestTools.validateAndNormalizeStartUrl(manifest.content.start_url,manifest,function(err,normManifest){
+      if(err){
+        console.log('Normalizing Error',err);
+        return reject(err);
+      }
 
-            manifest = _.assign(manifest,normManifest);
+      manifest = _.assign(manifest,normManifest);
 
-            resolve(manifest);
-        });
+      resolve(manifest);
     });
+  });
 };
 
 Manifold.prototype.createProject = function(manifest,outputDir,platforms,buildCordova){
-    var self = this;
+  var self = this;
 
-    return Q.Promise(function(resolve, reject){
-        var cleanManifest = _.omit(manifest,'id');
-        console.log('Building the project...',cleanManifest,outputDir,platforms,buildCordova);
-        self.lib.projectBuilder.createApps(cleanManifest, outputDir, platforms, buildCordova, function (err) {
+  return Q.Promise(function(resolve, reject){
+    var cleanManifest = _.omit(manifest,'id');
+    console.log('Building the project...',cleanManifest,outputDir,platforms,buildCordova);
+    try{
+      self.lib.projectBuilder.createApps(cleanManifest, outputDir, platforms, buildCordova, function (err) {
 
-            if(err){
-                console.log('Create Projects Errors!!!',err);
-                return reject(err);
-            }
+        if(err){
+          console.log('Create Projects Errors!!!',err);
+          return reject(err);
+        }
 
-            return resolve();
-        });
-    });
+        return resolve();
+      });
+    }catch(e){
+      return reject(e);
+    }
+  });
 };
 
 Manifold.prototype.assignValidationErrors = function(errors,manifest){
-    var data = { errors: []};
+  var data = { errors: []};
 
-    _.each(errors,function(e){
-        if(_.any(data.errors,'member',e.member)){
-            var error = _.find(data.errors,'member',e.member);
-            error.issues = error.issues || [];
-            error.issues.push({ description: e.description, platform: e.platform, code: e.code });
-        }else{
-            data.errors.push({
-                member: e.member,
-                issues: [{
-                    description: e.description,
-                    platform: e.platform,
-                    code: e.code
-                }]
-            });
-        }
-    });
+  _.each(errors,function(e){
+    if(_.any(data.errors,'member',e.member)){
+      var error = _.find(data.errors,'member',e.member);
+      error.issues = error.issues || [];
+      error.issues.push({ description: e.description, platform: e.platform, code: e.code });
+    }else{
+      data.errors.push({
+        member: e.member,
+        issues: [{
+          description: e.description,
+          platform: e.platform,
+          code: e.code
+        }]
+      });
+    }
+  });
 
-    manifest = _.assign(manifest,data);
+  manifest = _.assign(manifest,data);
 };
 
 Manifold.prototype.assignSuggestions = function(suggestions,manifest){
-    var data = { suggestions: []};
+  var data = { suggestions: []};
 
-    _.each(suggestions,function(s){
-        if(_.any(data.suggestions,'member',s.member)){
-            var suggestion = _.find(data.suggestions,'member',s.member);
-            suggestion.issues = suggestion.issues || [];
-            suggestion.issues.push({ description: s.description, platform: s.platform, code: s.code });
-        }else{
-            data.suggestions.push({
-                member: s.member,
-                issues: [{
-                    description: s.description,
-                    platform: s.platform,
-                    code: s.code
-                }]
-            });
-        }
-    });
+  _.each(suggestions,function(s){
+    if(_.any(data.suggestions,'member',s.member)){
+      var suggestion = _.find(data.suggestions,'member',s.member);
+      suggestion.issues = suggestion.issues || [];
+      suggestion.issues.push({ description: s.description, platform: s.platform, code: s.code });
+    }else{
+      data.suggestions.push({
+        member: s.member,
+        issues: [{
+          description: s.description,
+          platform: s.platform,
+          code: s.code
+        }]
+      });
+    }
+  });
 
-    manifest = _.assign(manifest,data);
+  manifest = _.assign(manifest,data);
 };
 
 Manifold.prototype.assignWarnings = function(warnings,manifest){
-    var data = { warnings: []};
+  var data = { warnings: []};
 
-    _.each(warnings,function(w){
-        if(_.any(data.warnings,'member',w.member)){
-            var warning = _.find(data.warnings,'member',w.member);
-            warning.issues = warning.issues || [];
-            warning.issues.push({ description: w.description, platform: w.platform, code: w.code });
-        }else{
-            data.warnings.push({
-                member: w.member,
-                issues: [{
-                    description: w.description,
-                    platform: w.platform,
-                    code: w.code
-                }]
-            });
-        }
-    });
+  _.each(warnings,function(w){
+    if(_.any(data.warnings,'member',w.member)){
+      var warning = _.find(data.warnings,'member',w.member);
+      warning.issues = warning.issues || [];
+      warning.issues.push({ description: w.description, platform: w.platform, code: w.code });
+    }else{
+      data.warnings.push({
+        member: w.member,
+        issues: [{
+          description: w.description,
+          platform: w.platform,
+          code: w.code
+        }]
+      });
+    }
+  });
 
-    manifest = _.assign(manifest,data);
+  manifest = _.assign(manifest,data);
 };
 
 exports.create = function(manifoldLib){
-    return new Manifold(manifoldLib);
+  return new Manifold(manifoldLib);
 };


### PR DESCRIPTION
Changing the way errors are handled in the build step to offer more insight into why a build failed to the visitor.

Currently, when an error gets thrown, the only messaging is that there was a "Internal Server Error."  That is not very helpful to them and makes it harder to address bugs for the development team.
