### PR TITLE
Removed projects folder from output path

### DIFF
--- a/src/services/storage.js
+++ b/src/services/storage.js
@@ -36,7 +36,7 @@ Storage.prototype.createZip = function(output, fileName){
         archive.pipe(zip);
 
         var folderName = path.join(output, utils.sanitizeName(fileName));
-        archive.directory(folderName, 'projects', { mode: '0755' }).finalize();
+        archive.directory(folderName, '', { mode: '0755' }).finalize();
     });
 };
 


### PR DESCRIPTION
This metod generates a 'projects' file that enlarges the output folder. Now we only return the root directory as initial folder.