### PR TITLE
Support msteams

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -15,6 +15,14 @@ var PWABuilder = {
   init: function(redisClient, azure, pwabuilder){
     var app = express();
 
+    redisClient.on('ready', () => {
+      console.log("Redis is ready");
+    });
+
+    redisClient.on('connect', () => {
+      console.log("Application has connected to redis");
+    });
+
     pwabuilder.log.setLevel('debug');
 
     // view engine setup

--- a/src/config/production.js
+++ b/src/config/production.js
@@ -9,7 +9,7 @@ module.exports = {
     'account_name': process.env.STORAGE_ACCOUNTNAME,
     'access_key': process.env.STORAGE_ACCESSKEY
   },
-  platforms: ['windows10', 'windows', 'android', 'ios', 'web', 'androidTWA', 'samsung'],
+  platforms: ['windows10', 'windows', 'android', 'ios', 'web', 'androidTWA', 'samsung', 'msteams'],
   images: {
     generationSvcUrl: process.env.IMG_GEN_SVC_URL || 'http://appimagegenerator-prod.azurewebsites.net'
   },

--- a/src/config/production.js
+++ b/src/config/production.js
@@ -9,7 +9,7 @@ module.exports = {
     'account_name': process.env.STORAGE_ACCOUNTNAME,
     'access_key': process.env.STORAGE_ACCESSKEY
   },
-  platforms: ['windows10', 'windows', 'android', 'ios', 'web', 'androidTWA', 'samsung', 'msteams'],
+  platforms: ['windows10', 'windows', 'android', 'ios', 'web', 'androidTWA', 'samsung'],
   images: {
     generationSvcUrl: process.env.IMG_GEN_SVC_URL || 'http://appimagegenerator-prod.azurewebsites.net'
   },

--- a/src/controllers/manifests.js
+++ b/src/controllers/manifests.js
@@ -1,7 +1,8 @@
 'use strict';
 
 var path    = require('path'),
-  outputDir = process.env.TMP,
+  os        = require('os'),
+  outputDir = os.tmpdir(),
   cheerio   = require('cheerio'),
   config    = require(path.join(__dirname,'../config')),
   util      = require('util'),
@@ -67,6 +68,8 @@ exports.create = function(client, storage, pwabuilder, raygun){
         if(!reply) return res.status(404).send('NOT FOUND');
 
         var platforms = req.body.platforms;
+        var parameters = req.body.parameters || [];
+
         if (!platforms) {
           // No platforms were selected by the user. Using default configured platforms.
           platforms = config.platforms;
@@ -86,12 +89,18 @@ exports.create = function(client, storage, pwabuilder, raygun){
         console.log("ManifestInfo: " + manifest);
 
         storage.removeDir(output)
-          .then(function(){ return pwabuilder.cleanGeneratedIcons(manifest); })
+          .then(function(){
+            if (platforms.indexOf('msteams') !== -1) {
+              return manifest;
+            }
+
+            return pwabuilder.cleanGeneratedIcons(manifest);
+          })
           .then(function(){ return pwabuilder.normalize(manifest); })
           .then(function(normManifest) {
               console.log('normManifest', normManifest);
               manifest = normManifest;
-              return pwabuilder.createProject(manifest, output, platforms, req.query.href || '', req.body.parameters);
+              return pwabuilder.createProject(manifest, output, platforms, req.query.href || '', parameters);
           })
           .then(function(projectDir){ 
             if(req.query.ids){

--- a/src/services/pwabuilder.js
+++ b/src/services/pwabuilder.js
@@ -403,12 +403,19 @@ PWABuilder.prototype.getServiceWorkerFromURL = function (url) {
       swInfo['scope'] = serviceWorkerScope;
 
       // checking push reg
-      const pushReg = await page.evaluate(() => {
+      var pushReg = await page.evaluate(() => {
         return navigator.serviceWorker.getRegistration().then((reg) => {
           return reg.pushManager.getSubscription().then((sub) => sub);
         });
       }, { timeout: config.serviceWorkerChecker.timeout });
 
+      if(!pushReg && swInfo.hasSW)
+      {
+        await page.goto(swInfo.hasSW, { waitUntil: ['domcontentloaded'] });
+        pushReg = await page.content().then((content) => {
+          return content.indexOf('self.addEventListener("push"') >= 0 || content.indexOf("self.addEventListener('push'") >= 0
+        });
+      }
       swInfo['pushReg'] = pushReg;
 
       // Checking cache

--- a/src/services/storage.js
+++ b/src/services/storage.js
@@ -20,7 +20,7 @@ Storage.prototype.createZip = function (output, fileName) {
     console.log('Creating zip archive...');
     var archive = archiver('zip'),
 
-      zip = fs.createWriteStream(path.join(output, fileName + '.zip'));
+      zip = fs.createWriteStream(path.join(output, fileName.replace(/[^a-zA-Z0-9]/g,'_') + '.zip'));
 
     zip.on('close', function () {
       console.log(archive.pointer() + ' total bytes');
@@ -35,7 +35,7 @@ Storage.prototype.createZip = function (output, fileName) {
 
     archive.pipe(zip);
 
-    var folderName = path.join(output, utils.sanitizeName(fileName));
+    var folderName = path.join(output, utils.sanitizeName(fileName.replace(/[^a-zA-Z0-9]/g,'_')));
     archive.directory(folderName, 'projects', { mode: '0755' }).finalize();
   });
 };
@@ -53,8 +53,8 @@ Storage.prototype.createContainer = function (containerName) {
 
 Storage.prototype.uploadZip = function (containerName, fileName, outputDir, suffix, blobName) {
   var extension = '.zip';
-  var _blobName = blobName || fileName;
-  return this.uploadFile(containerName, _blobName, path.join(outputDir, fileName + extension), extension, "-" + suffix);
+  var _blobName = blobName || fileName.replace(/[^a-zA-Z0-9]/g,'_');
+  return this.uploadFile(containerName, _blobName, path.join(outputDir, fileName.replace(/[^a-zA-Z0-9]/g,'_') + extension), extension, "-" + suffix);
 };
 
 Storage.prototype.uploadFile = function (containerName, fileName, filePath, extension, suffix) {
@@ -63,7 +63,7 @@ Storage.prototype.uploadFile = function (containerName, fileName, filePath, exte
     contentType = (extension == ".zip") ? 'application/zip' : 'application/octet-stream';
   return Q.Promise(function (resolve, reject) {
     console.log('Uploading ' + extension + '...');
-    self.blobService.createBlockBlobFromLocalFile(containerName, fileName + suffix + extension, filePath, { contentType: contentType }, function (err) {
+    self.blobService.createBlockBlobFromLocalFile(containerName, fileName.replace(/[^a-zA-Z0-9]/g,'_') + suffix + extension, filePath, { contentType: contentType }, function (err) {
       if (err) { return reject(err); }
       return resolve();
     });
@@ -151,7 +151,7 @@ Storage.prototype.removeDir = function (outputDir) {
 
 Storage.prototype.getUrlForFile = function (containerName, fileName, extension, suffix) {
   var container = suffix = suffix || '',
-    blob = fileName + suffix + extension;
+    blob = fileName.replace(/[^a-zA-Z0-9]/g,'_') + suffix + extension;
 
   var startDate = new Date();
   startDate.setMinutes(startDate.getMinutes() - 15);
@@ -173,13 +173,13 @@ Storage.prototype.getUrlForFile = function (containerName, fileName, extension, 
 };
 
 Storage.prototype.getUrlForZip = function (containerName, fileName, suffix) {
-  return this.getUrlForFile(containerName, fileName, '.zip', "-" + suffix);
+  return this.getUrlForFile(containerName, fileName.replace(/[^a-zA-Z0-9]/g,'_'), '.zip', "-" + suffix);
 };
 
 Storage.prototype.createZipFromDirs = function (folders, folderName, fileName) {
   return Q.Promise(function (resolve, reject) {
     console.log('Creating zip archive...');
-    var resultFilePath = path.join(folderName, fileName + '.zip');
+    var resultFilePath = path.join(folderName, fileName.replace(/[^a-zA-Z0-9]/g,'_') + '.zip');
     var archive = archiver('zip'),
 
       zip = fs.createWriteStream(resultFilePath);


### PR DESCRIPTION
1. adding a console log to the redis event emitter for local debugging.
2. prevent the omission of filenames from pwabuilder build for msteams (might want to split out the functionality in the future to keep this path clean).
3. added ability to pass down parameters (UI textual information) via options list rather than overriding the manifest (which can cause problems in the manifest normalization step).

Schema format:
{
  "<platform>": { <json to manually map> }
}