### PR TITLE
Fixed error: Cannot read property 'length' of undefined

### DIFF
--- a/src/services/pwabuilder.js
+++ b/src/services/pwabuilder.js
@@ -246,7 +246,7 @@ PWABuilder.prototype.normalize = function (manifest) {
 };
 
 PWABuilder.prototype.changeScreenshotPathsInManifest = function (manifest) {
-  for (var i = 0; i < manifest.content.screenshots.length; i++) {
+  for (var i = 0; i < manifest.content.screenshots && manifest.content.screenshots.length; i++) {
     if (manifest.content.screenshots[i].generated) {
       manifest.content.screenshots[i].src =
         manifest.content.screenshots[i].fileName;


### PR DESCRIPTION
Checking if manifest.content.screenshots is existed before using length property.