### PR TITLE
skip screenshots relative path section if no screenshots.

### DIFF
--- a/src/services/pwabuilder.js
+++ b/src/services/pwabuilder.js
@@ -246,6 +246,10 @@ PWABuilder.prototype.normalize = function (manifest) {
 };
 
 PWABuilder.prototype.changeScreenshotPathsInManifest = function (manifest) {
+  if (!manifest.content.screenshots) {
+    return manifest;
+  }
+
   for (var i = 0; i < manifest.content.screenshots.length; i++) {
     if (manifest.content.screenshots[i].generated) {
       manifest.content.screenshots[i].src =


### PR DESCRIPTION
the screenshots section fails if the manifest doesn't have a screenshots entry.

found while investigating:
https://github.com/pwa-builder/pwabuilder-MacOS/issues/17