### PR TITLE
Resolve relative url (#1154)

### DIFF
--- a/src/controllers/manifests.js
+++ b/src/controllers/manifests.js
@@ -117,7 +117,7 @@ exports.create = function (client, storage, pwabuilder, raygun) {
             return pwabuilder.changeScreenshotPathsInManifest(manifest);
           })
           .then(function () {
-            return pwabuilder.normalize(manifest, req.params.href);
+            return pwabuilder.normalize(manifest, req.query.href);
           })
           .then(function (normManifest) {
             ////console.log('normManifest', normManifest);

--- a/src/controllers/manifests.js
+++ b/src/controllers/manifests.js
@@ -112,7 +112,7 @@ exports.create = function (client, storage, pwabuilder, raygun) {
             return pwabuilder.changeScreenshotPathsInManifest(manifest);
           })
           .then(function () {
-            return pwabuilder.normalize(manifest, req.query.href);
+            return pwabuilder.normalize(manifest);
           })
           .then(function (normManifest) {
             ////console.log('normManifest', normManifest);

--- a/src/controllers/manifests.js
+++ b/src/controllers/manifests.js
@@ -72,11 +72,6 @@ exports.create = function (client, storage, pwabuilder, raygun) {
     },
     // Create zip for user to download
     build: function (req, res) {
-      //TODO see the manifest info
-
-      console.log(pwabuilder.log);
-      console.log("testing 2");
-
       client.get(req.params.id, function (err, reply) {
         if (err) {
           //raygun.send(err);
@@ -345,8 +340,6 @@ exports.create = function (client, storage, pwabuilder, raygun) {
     },
     // Send to our DropBox
     package: function (req, res) {
-      console.log(req);
-
       client.get(req.params.id, function (err, reply) {
         if (err) {
           //raygun.send(err);

--- a/src/controllers/manifests.js
+++ b/src/controllers/manifests.js
@@ -72,6 +72,11 @@ exports.create = function (client, storage, pwabuilder, raygun) {
     },
     // Create zip for user to download
     build: function (req, res) {
+      //TODO see the manifest info
+
+      console.log(pwabuilder.log);
+      console.log("testing 2");
+
       client.get(req.params.id, function (err, reply) {
         if (err) {
           //raygun.send(err);
@@ -112,7 +117,7 @@ exports.create = function (client, storage, pwabuilder, raygun) {
             return pwabuilder.changeScreenshotPathsInManifest(manifest);
           })
           .then(function () {
-            return pwabuilder.normalize(manifest);
+            return pwabuilder.normalize(manifest, req.params.href);
           })
           .then(function (normManifest) {
             ////console.log('normManifest', normManifest);
@@ -340,6 +345,8 @@ exports.create = function (client, storage, pwabuilder, raygun) {
     },
     // Send to our DropBox
     package: function (req, res) {
+      console.log(req);
+
       client.get(req.params.id, function (err, reply) {
         if (err) {
           //raygun.send(err);

--- a/src/services/pwabuilder.js
+++ b/src/services/pwabuilder.js
@@ -257,7 +257,7 @@ PWABuilder.prototype.updateManifest = function (
   });
 };
 
-PWABuilder.prototype.normalize = function (manifest, baseUrl) {
+PWABuilder.prototype.normalize = function (manifest) {
   var self = this;
 
   return Q.Promise(function (resolve, reject) {
@@ -286,9 +286,8 @@ PWABuilder.prototype.normalize = function (manifest, baseUrl) {
       manifest.content.name = manifest.content.name.replace(/-/g, ' ');
     }
 
-    var normalizedUrl = url.parse(baseUrl, manifest.content.start_url);
-    if (typeof normalizedUrl !== "string") {
-      normalizedUrl = normalizedUrl.href;
+    if (manifest.start_url === ".") {
+      manifest.start_url = "/";
     }
 
     self.lib.manifestTools.validateAndNormalizeStartUrl(

--- a/src/services/pwabuilder.js
+++ b/src/services/pwabuilder.js
@@ -256,7 +256,7 @@ PWABuilder.prototype.updateManifest = function (
   });
 };
 
-PWABuilder.prototype.normalize = function (manifest) {
+PWABuilder.prototype.normalize = function (manifest, baseUrl) {
   var self = this;
 
   return Q.Promise(function (resolve, reject) {
@@ -285,9 +285,13 @@ PWABuilder.prototype.normalize = function (manifest) {
       manifest.content.name = manifest.content.name.replace(/-/g, ' ');
     }
 
-    //console.log('Validating start url...', manifest);
+    var normalizedUrl = url.parse(baseUrl, manifest, content.start_url) 
+    if (typeof normalizedUrl !== "string") {
+      normalizedUrl = normalizedUrl.toString();
+    }
+
     self.lib.manifestTools.validateAndNormalizeStartUrl(
-      manifest.content.start_url,
+      normalizedUrl,
       manifest,
       function (err, normManifest) {
         if (err) {

--- a/src/services/pwabuilder.js
+++ b/src/services/pwabuilder.js
@@ -3,6 +3,7 @@
 var uuid = require('uuid'),
   Q = require('q'),
   _ = require('lodash'),
+  url = require('url'),
   path = require('path'),
   config = require(path.join(__dirname, '../config')),
   puppeteer = require('puppeteer'),
@@ -285,9 +286,9 @@ PWABuilder.prototype.normalize = function (manifest, baseUrl) {
       manifest.content.name = manifest.content.name.replace(/-/g, ' ');
     }
 
-    var normalizedUrl = url.parse(baseUrl, manifest, content.start_url) 
+    var normalizedUrl = url.parse(baseUrl, manifest.content.start_url);
     if (typeof normalizedUrl !== "string") {
-      normalizedUrl = normalizedUrl.toString();
+      normalizedUrl = normalizedUrl.href;
     }
 
     self.lib.manifestTools.validateAndNormalizeStartUrl(
@@ -295,7 +296,7 @@ PWABuilder.prototype.normalize = function (manifest, baseUrl) {
       manifest,
       function (err, normManifest) {
         if (err) {
-          //console.log('Normalizing Error', err);
+          // console.log('Normalizing Error', err);
           return reject(err);
         }
 


### PR DESCRIPTION
Part of issue
https://github.com/pwa-builder/PWABuilder/issues/1154

Edit: changed my earlier changed to something simpler: just set "." to "/".

The current path passes the start_url in the manifest as the url used to resolve paths, this throws an exception when "." is used. So like the image paths being set to their full url lengths. The start url is being set as well for the normalization step.