### PR TITLE
Default short name gen doesn't work with relative urls.

### DIFF
--- a/src/controllers/manifests.js
+++ b/src/controllers/manifests.js
@@ -112,7 +112,7 @@ exports.create = function (client, storage, pwabuilder, raygun) {
             return pwabuilder.changeScreenshotPathsInManifest(manifest);
           })
           .then(function () {
-            return pwabuilder.normalize(manifest);
+            return pwabuilder.normalize(manifest, req.query.href);
           })
           .then(function (normManifest) {
             ////console.log('normManifest', normManifest);

--- a/src/services/pwabuilder.js
+++ b/src/services/pwabuilder.js
@@ -257,7 +257,7 @@ PWABuilder.prototype.updateManifest = function (
   });
 };
 
-PWABuilder.prototype.normalize = function (manifest) {
+PWABuilder.prototype.normalize = function (manifest, siteUrl) {
   var self = this;
 
   return Q.Promise(function (resolve, reject) {
@@ -291,7 +291,7 @@ PWABuilder.prototype.normalize = function (manifest) {
     }
 
     self.lib.manifestTools.validateAndNormalizeStartUrl(
-      manifest.content.start_url,
+      siteUrl,
       manifest,
       function (err, normManifest) {
         if (err) {


### PR DESCRIPTION
current issue, but should be tied to a few more too:
https://github.com/pwa-builder/PWABuilder/issues/1184

produces null in parsed url when supplied with:
url.parse(".")
url.parse("/")

hostname == null in this situation.

Usage here:
https://github.com/pwa-builder/pwabuilder-lib/blob/65298d604db10bc15308a29d025142bf84a49ef3/lib/utils.js#L82